### PR TITLE
feat: Evitando usar a API para obter fotos de perfil

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,6 +1,7 @@
 //import contributors from "./data/_contributors.json"
 
 const API_URL = 'https://api.github.com/users/';
+const GITHUB_URL = 'https://github.com/';
 
 const contributor_section = document.getElementById('section-contributors');
 
@@ -22,7 +23,6 @@ const make_contributor = async (user) => {
   const user_data = await get_user_data(user.username);
   const contributor = {
     ...user,
-    avatar_url: user_data.avatar_url,
     name: user_data.name,
   };
   return contributor;
@@ -35,7 +35,7 @@ const create_contributor_card = (user) => {
   });
   const cardHTML = `
             <div>
-                <img class="avatar" src="${user.avatar_url}" alt="${
+                <img class="avatar" src="${GITHUB_URL + user.username + '.png'}" alt="${
     user.name
   }" />
             </div>

--- a/script.js
+++ b/script.js
@@ -35,9 +35,7 @@ const create_contributor_card = (user) => {
   });
   const cardHTML = `
             <div>
-                <img class="avatar" src="${GITHUB_URL + user.username + '.png'}" alt="${
-    user.name
-  }" />
+                <img class="avatar" src="${GITHUB_URL + user.username + '.png'}" alt="${user.username}" />
             </div>
             <div class="user-info">
                 <h2>${user.name || user.username}</h2>


### PR DESCRIPTION
O GitHub possui uma API com um rate limit muito baixo.

Assim, podemos continuar exibindo as fotos, mesmo que o limite tenha sido atingido. 